### PR TITLE
revert to using a 2 channel motor driver on pins D1, D2

### DIFF
--- a/train_controller/.gitignore
+++ b/train_controller/.gitignore
@@ -1,0 +1,2 @@
+secrets.h
+.DS_Store

--- a/train_controller/train_controller.ino
+++ b/train_controller/train_controller.ino
@@ -4,14 +4,12 @@
 #include <ESP8266WiFi.h>
 #include <ESP8266WebServer.h>
 #include <ElegantOTA.h>         // v2.2.9
-#include <Servo.h>
 #include "secrets.h"
 
 WiFiClient wc;
 MqttClient mqttClient(wc);
 ESP8266WebServer server(80);
 
-Servo esc;
 const char broker[] = "172.17.17.181";
 int        port     = 1883;
 const char topic[]  = "train/control/speed";
@@ -20,7 +18,10 @@ const char topic[]  = "train/control/speed";
 void (* resetFunc) (void) = 0;
 
 void setup() {
-	esc.attach(D1);
+	pinMode(D1, OUTPUT);
+	pinMode(D2, OUTPUT);
+	digitalWrite(D1, LOW);
+	digitalWrite(D2, LOW);
 
 	Serial.begin(115200);
 	Serial.println("");
@@ -167,5 +168,11 @@ void processControlCommand(int64_t num) {
 
 	Serial.print("[CHOO] Setting power: ");
 	Serial.println(num);
-	esc.write(num);
+	if (num > 0) {
+		analogWrite(D1, num);
+		analogWrite(D2, 0);
+	} else {
+		analogWrite(D1, 0);
+		analogWrite(D2, -num);
+	}
 }


### PR DESCRIPTION
Change the train firmware for compatibility with DRV8833-style speed controllers. D1 and D1 are PWM'd to adjust the speed on motor channel 1. 

This is the current 3D printed train design in the welcome room.

MQTT protocol has not been changed. 